### PR TITLE
feat: export NgxMatDatepickerInputEvent

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # FORKED FROM [h2qutc/angular-material-components](https://github.com/h2qutc/angular-material-components)
 
-# Angular Material Extra Components (DatetimePicker, TimePicker, ColorPicker, FileInput ...) for @angular/material 7.x, 8.x, 9.x, 10.x, 11.x, 12.x, 13.x, 14.x, 15.x, 16.x
+# Angular Material Extra Components (DatetimePicker, TimePicker, ColorPicker, FileInput ...) for @angular/material 7.x, 8.x, 9.x, 10.x, 11.x, 12.x, 13.x, 14.x, 15.x, 16.x, 18.x, 19.x
 
 [![Build Status](https://travis-ci.com/h2qutc/angular-material-components.svg?branch=master)](https://travis-ci.com/h2qutc/angular-material-components)
 [![License](https://img.shields.io/npm/l/angular-material-components.svg)](https://www.npmjs.com/package/angular-material-components)
@@ -28,8 +28,10 @@ And thank you so much for your coffee ❤️
 Choose the version corresponding to your Angular version:
 
 | Angular | @ngxmc/datetime-picker          |
-| ------- | ------------------------------- |
-| 16      | 16.x+                           |
+|---------|---------------------------------|
+| 19      | 19.x+                           |
+| 18      | 18.x+                           |
+| 17      | none                            |
 | 15      | 15.x+ OR 9.x+ for legacy import |
 | 14      | 8.x+                            |
 | 13      | 7.x+                            |

--- a/projects/datetime-picker/src/lib/index.ts
+++ b/projects/datetime-picker/src/lib/index.ts
@@ -9,6 +9,7 @@ export * from './datepicker';
 export * from './datepicker-actions';
 export * from './datepicker-base';
 export * from './datepicker-input';
+export { NgxMatDatepickerInputEvent } from './datepicker-input-base';
 export * from './datepicker-toggle';
 export * from './month-view';
 export * from './multi-year-view';


### PR DESCRIPTION
Hey, i've found your fork useful for our project. Thanks for keeping this components up with latest version of angular. 

This PR exporting the `NgxMatDatepickerInputEvent` and also updating docs to reflect support of angular 18/19. 

Motivation
I find very useful to have the `NgxMatDatepickerInputEvent` exported to be used in the consumers code like this:

```ts
  handleDateChange(event: NgxMatDatepickerInputEvent<Date>): void {
    this.setDate(event);
    this.params.stopEditing();
  }

  handleDateInput(event: NgxMatDatepickerInputEvent<Date>): void {
    this.setDate(event);
  }
```

Currently, I have to import a private path inside the package which may break at any moment

```ts
import { NgxMatDatepickerInputEvent } from '@ngxmc/datetime-picker/lib/datepicker-input-base';

```

PS
Could you enable issues for this repo? I believe it's disabled by default because it's a fork. 
